### PR TITLE
Linker Fix for Servo 360 Libraries

### DIFF
--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -269,10 +269,10 @@ class PropCCompiler:
         executing_data.append(main_c_file_name)
 
         libraries = descriptors.keys()
-        executing_data.append('-Wl,--start-group')
+        executing_data.append("-Wl,--start-group")
         executing_data.append("-lm")
         for library in libraries:
             executing_data.append("-l" + library)
-        executing_data.append('-Wl,--end-group')
+        executing_data.append("-Wl,--end-group")
 
         return executing_data

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -274,13 +274,10 @@ class PropCCompiler:
         executing_data.append(main_c_file_name)
         
         libraries = descriptors.keys()
-        if len(libraries) == 0:
-            executing_data.append("-lm")
-        else:
-            executing_data.append('-\(')
-            for library in libraries:
-                executing_data.append("-l" + library)
-            executing_data.append("-lm")
-            executing_data.append('-\)')
+        executing_data.append('-Wl,--start-group')
+        executing_data.append("-lm")
+        for library in libraries:
+            executing_data.append("-l" + library)
+        executing_data.append('-Wl,--end-group')
 
         return executing_data

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -185,6 +185,11 @@ class PropCCompiler:
         print(' '.join(executing_data))
 
         try:
+
+            f = open('command-line.txt','w')
+            f.write('\n\nWorking Directory: ' + working_directory + '\n\nCommand line: ' + ' '.join(executing_data))
+            f.close()
+
             process = subprocess.Popen(executing_data, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_directory)  # call compile
 
             out, err = process.communicate()
@@ -277,9 +282,5 @@ class PropCCompiler:
                 executing_data.append("-l" + library)
             executing_data.append("-lm")
             executing_data.append('-\)')
-
-        f = open('command-line.txt','w')
-        f.write(str(executing_data))
-        f.close()
 
         return executing_data

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -267,7 +267,7 @@ class PropCCompiler:
         for binary in binaries:
             executing_data.append(binary + ".o")
         executing_data.append(main_c_file_name)
-        
+
         libraries = descriptors.keys()
         executing_data.append('-Wl,--start-group')
         executing_data.append("-lm")

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -267,13 +267,19 @@ class PropCCompiler:
         for binary in binaries:
             executing_data.append(binary + ".o")
         executing_data.append(main_c_file_name)
-        executing_data.append("-lm")
-
+        
         libraries = descriptors.keys()
-        while len(libraries) > 0:
+        if len(libraries) == 0:
+            executing_data.append("-lm")
+        else:
+            executing_data.append('-\(')
             for library in libraries:
                 executing_data.append("-l" + library)
             executing_data.append("-lm")
-            del libraries[-1]
+            executing_data.append('-\)')
+
+        f = open('command-line.txt','w')
+        f.write(str(executing_data))
+        f.close()
 
         return executing_data

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -185,11 +185,6 @@ class PropCCompiler:
         print(' '.join(executing_data))
 
         try:
-
-            f = open('command-line.txt','w')
-            f.write('\n\nWorking Directory: ' + working_directory + '\n\nCommand line: ' + ' '.join(executing_data))
-            f.close()
-
             process = subprocess.Popen(executing_data, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_directory)  # call compile
 
             out, err = process.communicate()

--- a/cloudcompiler.py
+++ b/cloudcompiler.py
@@ -10,7 +10,7 @@ import base64
 
 __author__ = 'Michel'
 
-version = "1.0.0"
+version = "1.1.0"
 app = Flask(__name__)
 
 

--- a/cloudcompiler.py
+++ b/cloudcompiler.py
@@ -10,7 +10,7 @@ import base64
 
 __author__ = 'Michel'
 
-version = "1.1.0"
+version = "1.0.1"
 app = Flask(__name__)
 
 


### PR DESCRIPTION
Changes how the linker builds the project, so that it automatically resolves all symbols regardless of library #include order.

This should be merged _before_ deploying Cloud-Compiler **Master** branch to **bpstaging**.