### PR TITLE
Python3

### DIFF
--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -81,12 +81,16 @@ class PropCCompiler:
         for filename in source_files:
             if filename.endswith(".c"):
                 with open(source_directory + "/" + filename, mode='w') as source_file:
-                    cloudcompiler.app.logger.info("Source file is of type: %s",
-                                                  type(source_files[filename]))
+                    cloudcompiler.app.logger.debug(
+                        "Source file is of type: %s",
+                        type(source_files[filename]))
+
                     if isinstance(source_files[filename], str):
                         file_content = source_files[filename]
+
                     elif isinstance(source_files[filename], bytes):
                         file_content = source_files[filename].decode()
+
                     elif isinstance(source_files[filename], FileStorage):
                         file_content = source_files[filename].stream.read()
 
@@ -142,11 +146,11 @@ class PropCCompiler:
         err = None
 
         if success:
-            cloudcompiler.app.logger.info("Source directory: %s", source_directory)
-            cloudcompiler.app.logger.info("Action          : %s", action)
-            cloudcompiler.app.logger.info("App File Name   : %s", app_filename)
-            cloudcompiler.app.logger.info("Library order   : %s", library_order)
-            cloudcompiler.app.logger.info("External libs   : %s", external_libraries_info)
+            cloudcompiler.app.logger.debug("Source directory: %s", source_directory)
+            cloudcompiler.app.logger.debug("Action          : %s", action)
+            cloudcompiler.app.logger.debug("App File Name   : %s", app_filename)
+            cloudcompiler.app.logger.debug("Library order   : %s", library_order)
+            cloudcompiler.app.logger.debug("External libs   : %s", external_libraries_info)
 
             # Compile binary
             (bin_success, base64binary, out, err) = self.compile_binary(


### PR DESCRIPTION
Refactor compiler status information as a series of debug messages.
Update logging configuration to support multiple loggers; one for python, one for the flask app and one more for the WSGI web services. 

All of these loggers send their output to stderr, which means that the hosting container can redirect the logs messages to an external logging service, such as CloudWatch.