### PR TITLE
Release v1.3.4

### DIFF
--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -205,9 +205,11 @@ class PropCCompiler:
                     library_present = True
                     if library + '.c' in files:
                         with open(root + '/' + library + '.c') as library_code:
+                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.c')
                             includes = self.parse_includes(library_code.read())
                     else:
                         with open(root + '/' + library + '.h') as header_code:
+                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.h')
                             includes = self.parse_includes(header_code.read())
 
                     libraries[library] = {

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -25,14 +25,12 @@ import base64
 import shutil
 from werkzeug.datastructures import FileStorage
 
-import sys
 import os
 import subprocess
 import re
 
 from tempfile import NamedTemporaryFile, mkdtemp
-# from cloudcompiler import app
-import cloudcompiler
+from cloudcompiler import app
 
 __author__ = 'Michel'
 
@@ -81,7 +79,8 @@ class PropCCompiler:
         for filename in source_files:
             if filename.endswith(".c"):
                 with open(source_directory + "/" + filename, mode='w') as source_file:
-                    cloudcompiler.app.logger.debug(
+
+                    app.logger.debug(
                         "Source file is of type: %s",
                         type(source_files[filename]))
 
@@ -146,11 +145,11 @@ class PropCCompiler:
         err = None
 
         if success:
-            cloudcompiler.app.logger.debug("Source directory: %s", source_directory)
-            cloudcompiler.app.logger.debug("Action          : %s", action)
-            cloudcompiler.app.logger.debug("App File Name   : %s", app_filename)
-            cloudcompiler.app.logger.debug("Library order   : %s", library_order)
-            cloudcompiler.app.logger.debug("External libs   : %s", external_libraries_info)
+            app.logger.debug("Source directory: %s", source_directory)
+            app.logger.debug("Action          : %s", action)
+            app.logger.debug("App File Name   : %s", app_filename)
+            app.logger.debug("Library order   : %s", library_order)
+            app.logger.debug("External libs   : %s", external_libraries_info)
 
             # Compile binary
             (bin_success, base64binary, out, err) = self.compile_binary(
@@ -204,12 +203,12 @@ class PropCCompiler:
                 if library in root[root.rindex('/') + 1:]:
                     library_present = True
                     if library + '.c' in files:
-                        with open(root + '/' + library + '.c') as library_code:
-                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.c')
+                        with open(root + '/' + library + '.c', encoding="latin-1") as library_code:
+                            app.logger.info("Parsing '%s'", root + '/' + library + '.c')
                             includes = self.parse_includes(library_code.read())
                     else:
-                        with open(root + '/' + library + '.h') as header_code:
-                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.h')
+                        with open(root + '/' + library + '.h', encoding="latin-1") as header_code:
+                            app.logger.info("Parsing '%s'", root + '/' + library + '.h')
                             includes = self.parse_includes(header_code.read())
 
                     libraries[library] = {
@@ -230,9 +229,8 @@ class PropCCompiler:
             return False, 'Library %s not found' % library
 
     def compile_lib(self, working_directory, source_file, target_filename, libraries):
-        cloudcompiler.app.logger.info("Working directory: %s", working_directory)
-        cloudcompiler.app.logger.info("Compiling source file: %s to target file: %s",
-                                      source_file, target_filename)
+        app.logger.info("Working directory: %s", working_directory)
+        app.logger.info("Compiling source file: %s to target file: %s", source_file, target_filename)
 
         executing_data = self.create_lib_executing_data(source_file, target_filename, libraries)  # build execution command
 

--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -30,7 +30,7 @@ import subprocess
 import re
 
 from tempfile import NamedTemporaryFile, mkdtemp
-from cloudcompiler import app
+import cloudcompiler
 
 __author__ = 'Michel'
 
@@ -80,7 +80,7 @@ class PropCCompiler:
             if filename.endswith(".c"):
                 with open(source_directory + "/" + filename, mode='w') as source_file:
 
-                    app.logger.debug(
+                    cloudcompiler.app.logger.debug(
                         "Source file is of type: %s",
                         type(source_files[filename]))
 
@@ -145,11 +145,11 @@ class PropCCompiler:
         err = None
 
         if success:
-            app.logger.debug("Source directory: %s", source_directory)
-            app.logger.debug("Action          : %s", action)
-            app.logger.debug("App File Name   : %s", app_filename)
-            app.logger.debug("Library order   : %s", library_order)
-            app.logger.debug("External libs   : %s", external_libraries_info)
+            cloudcompiler.app.logger.debug("Source directory: %s", source_directory)
+            cloudcompiler.app.logger.debug("Action          : %s", action)
+            cloudcompiler.app.logger.debug("App File Name   : %s", app_filename)
+            cloudcompiler.app.logger.debug("Library order   : %s", library_order)
+            cloudcompiler.app.logger.debug("External libs   : %s", external_libraries_info)
 
             # Compile binary
             (bin_success, base64binary, out, err) = self.compile_binary(
@@ -204,11 +204,11 @@ class PropCCompiler:
                     library_present = True
                     if library + '.c' in files:
                         with open(root + '/' + library + '.c', encoding="latin-1") as library_code:
-                            app.logger.info("Parsing '%s'", root + '/' + library + '.c')
+                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.c')
                             includes = self.parse_includes(library_code.read())
                     else:
                         with open(root + '/' + library + '.h', encoding="latin-1") as header_code:
-                            app.logger.info("Parsing '%s'", root + '/' + library + '.h')
+                            cloudcompiler.app.logger.info("Parsing '%s'", root + '/' + library + '.h')
                             includes = self.parse_includes(header_code.read())
 
                     libraries[library] = {
@@ -229,8 +229,8 @@ class PropCCompiler:
             return False, 'Library %s not found' % library
 
     def compile_lib(self, working_directory, source_file, target_filename, libraries):
-        app.logger.info("Working directory: %s", working_directory)
-        app.logger.info("Compiling source file: %s to target file: %s", source_file, target_filename)
+        cloudcompiler.app.logger.info("Working directory: %s", working_directory)
+        cloudcompiler.app.logger.info("Compiling source file: %s to target file: %s", source_file, target_filename)
 
         executing_data = self.create_lib_executing_data(source_file, target_filename, libraries)  # build execution command
 

--- a/__version__.py
+++ b/__version__.py
@@ -1,4 +1,3 @@
 
 
-
-version = "1.3.3"
+version = "1.3.4"

--- a/__version__.py
+++ b/__version__.py
@@ -1,4 +1,4 @@
 
 
 
-version = "1.3.2"
+version = "1.3.3"

--- a/cloudcompiler.py
+++ b/cloudcompiler.py
@@ -37,7 +37,7 @@ from PropCCompiler import PropCCompiler
 
 __author__ = 'Michel'
 
-version = "1.3.2"
+version = "1.3.3"
 
 # Set up basic logging
 logging.basicConfig(

--- a/cloudcompiler.py
+++ b/cloudcompiler.py
@@ -37,7 +37,7 @@ from PropCCompiler import PropCCompiler
 
 __author__ = 'Michel'
 
-version = "1.3.3"
+version = "1.3.4"
 
 # Set up basic logging
 logging.basicConfig(


### PR DESCRIPTION
Addresses issue parallaxinc/solo#74.

Adjusts the default behavior of text file processing in Python3 to allow the file reader to ingest non-ASCII characters from the file. The new setting will permit the entire Latin-1 character set.

Updates application logging to use streams instead of files. This change allows log entries to be pushed in real-time to a logging service, such as Cloudwatch. It also eliminates the process of managing a growing collection of log files in the containers.
