### PR TITLE
Corrected error in file open to now support UTF-8 character set.

### DIFF
--- a/PropCCompiler.py
+++ b/PropCCompiler.py
@@ -56,7 +56,7 @@ class PropCCompiler:
         # Header files
         for filename in source_files:
             if filename.endswith(".h"):
-                with open(source_directory + "/" + filename, mode='w') as header_file:
+                with open(source_directory + "/" + filename, mode='w', encoding='utf-8') as header_file:
                     if isinstance(source_files[filename], str):
                         file_content = source_files[filename]
                     elif isinstance(source_files[filename], FileStorage):
@@ -78,7 +78,7 @@ class PropCCompiler:
         # their contents to physical files that the compiler can see.
         for filename in source_files:
             if filename.endswith(".c"):
-                with open(source_directory + "/" + filename, mode='w') as source_file:
+                with open(source_directory + "/" + filename, mode='w', encoding='utf-8') as source_file:
 
                     cloudcompiler.app.logger.debug(
                         "Source file is of type: %s",

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 
 
-version = "1.3.7"
+version = "1.3.8"
 
 # Change Log
 #


### PR DESCRIPTION
Source files submitted to the compiler service may contain extended characters in the source comments. In the example reported, the degree symbol trigger a fault in the server code. This update addressed that issue by adding a encoding='utf-8' setting to the file.open(). This will ensure that file writes will not fail when extended characters are encountered in the file.

Bumping to version 3.1.8