### PR TITLE
Add check for missing source code in the request

### DIFF
--- a/cloudcompiler.py
+++ b/cloudcompiler.py
@@ -164,7 +164,8 @@ def single_c(action):
     src = request.data
     source = ""
 
-    if src is None:
+    # Fail if no source code provided
+    if src == b'':
         return Response(json.dumps({
             "success": False,
             "message": "Source code is missing",


### PR DESCRIPTION
The server generates a '500' error when a POST request that does not provide anything in the body of the request is made to the server. This update evaluates that possibility and fails the requests if the source is missing in the body of the request.

Sets build version to 1.3.13.
